### PR TITLE
Fix: Add blank canvas detection and warning for predictions

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,12 +22,15 @@ canvas_result = st_canvas(
 )
 
 if canvas_result.image_data is not None:
-    img = canvas_result.image_data[:, :, 0]
+    img = canvas_result.image_data[:, :, 0]  # Get 1 channel (grayscale)
     img = Image.fromarray(img).resize((28, 28)).convert("L")
     img = np.array(img)
     img = img.reshape(1, 28, 28, 1) / 255.0
 
-    pred = model.predict(img)
-    predicted_digit = np.argmax(pred)
-
-    st.subheader(f"Predicted Digit: {predicted_digit}")
+    # Check if the drawing is basically blank
+    if np.sum(img) < 10:
+        st.warning("🖼️ Please draw a digit before predicting.")
+    else:
+        pred = model.predict(img)
+        predicted_digit = np.argmax(pred)
+        st.subheader(f"Predicted Digit: {predicted_digit}")


### PR DESCRIPTION
- Added a check to detect if the canvas is blank (drawing has no content)
- If blank, shows a warning instead of making a prediction
- Improves user experience by preventing incorrect predictions on empty canvases